### PR TITLE
Fix bowser es import

### DIFF
--- a/src/BrowserPopupWindow.ts
+++ b/src/BrowserPopupWindow.ts
@@ -1,4 +1,4 @@
-import * as Bowser from 'bowser';
+import Bowser from 'bowser';
 
 const browser = Bowser.getParser(window.navigator.userAgent);
 


### PR DESCRIPTION
Hey there! "bowser" exports the Bowser class as `export default Bowser`. Unfortunately this means that `import * as Bowser` is impossible, since a class can't be converted into an entire ESM module namespace.

This is currently failing in Rollup, Snowpack, and possibly some other browsers. See: https://github.com/snowpackjs/snowpack/discussions/2680#discussioncomment-399383